### PR TITLE
Update logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://bun.sh"><img src="https://github.com/user-attachments/assets/438e74e0-cbb0-4c11-ba3d-a2c0347f70f0" alt="Logo" height=170></a>
+  <a href="https://bun.sh"><img src="https://github.com/user-attachments/assets/7b8513ef-6ae9-47ef-9d18-1f2c958fbd3e" alt="Logo" height=170></a>
 </p>
 <h1 align="center">Bun</h1>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://bun.sh"><img src="https://github.com/user-attachments/assets/50282090-adfd-4ddb-9e27-c30753c6b161" alt="Logo" height=170></a>
+  <a href="https://bun.sh"><img src="https://github.com/user-attachments/assets/438e74e0-cbb0-4c11-ba3d-a2c0347f70f0" alt="Logo" height=170></a>
 </p>
 <h1 align="center">Bun</h1>
 


### PR DESCRIPTION
Corrects previously cropped logo in README with size-optimized 2x pixel density version. New version also uses more accurate color space (the colors are true to SVG now).

Before:
![image](https://github.com/user-attachments/assets/3966169a-62af-4c20-b59c-dc6cdefa3d9a)
Logo image size: **22.4 KB**

After:
![image](https://github.com/user-attachments/assets/73addeee-0324-41ae-95e2-75a3bca60280)
Logo image size: **10.5 KB**

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)